### PR TITLE
updateJinja2Version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ certifi==2015.4.28
 czipfile==1.0.0
 docutils==0.12
 elasticsearch==1.6.0
-Jinja2==2.8
+Jinja2==2.10.1
 MarkupSafe==0.23
 nose==1.3.7
 mock==2.0.0


### PR DESCRIPTION
Jinja2 vulnerabilities were published in CVE. Description below:
CVE-2019-10906	In Pallets Jinja before 2.10.1, str.format_map allows a sandbox escape.
CVE-2016-10745	In Pallets Jinja before 2.8.1, str.format allows a sandbox escape.
Affected versions of this package are vulnerable to Sandbox Bypass. Users were allowed to insert str.format through web templates, leading to an escape from sandbox. The problem has been solved in version 2.10.1, so updating to this point is beneficial.